### PR TITLE
Updates Gradle dependencies so it is compatible with Gradle 5.x

### DIFF
--- a/LibRootbeerFresh/build.gradle
+++ b/LibRootbeerFresh/build.gradle
@@ -38,7 +38,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.3'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
 
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
@@ -140,8 +140,10 @@ artifacts {
     archives sourcesJar
 }
 
-task findConventions << {
-    println project.getConvention()
+task findConventions {
+    doLast {
+        println project.getConvention()
+    }
 }
 
 apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.3'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
 
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
@@ -24,7 +24,7 @@ android {
         minSdkVersion minSdkVer
         targetSdkVersion targetSdkVer
         versionCode 10
-        versionName "0.10"
+        versionName "0.0.10"
     }
 
     //check if the keystore details are defined in gradle.properties (this is so the key is not in github)

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
 VERSION_NAME=0.0.10
 VERSION_CODE=10
 GROUP=com.kimchangyoun


### PR DESCRIPTION
This simply replaces the syntax of `<<` operator (already deprecated in Gradle 4.x, not supported in 5.x) to a compatible one, and updates `jacoco-android` to fix an issue with Gradle 5.x (see https://github.com/arturdm/jacoco-android-gradle-plugin/issues/54 ).